### PR TITLE
Update confidence threshold values and sync returned answer count with threshold answer count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@
 **/bower_components
 **/node
 **/node_modules
-**/webapp/js/bundle.js
-**/webapp/css
+questions-with-classifier-ega-war/src/main/webapp/js/bundle.js
+questions-with-classifier-ega-war/src/main/webapp/css
 **/bootstrap
 **/_bootstrap*
 **/.DS_Store
+*.log

--- a/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/SampleQuestions.java
+++ b/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/SampleQuestions.java
@@ -25,10 +25,10 @@ public class SampleQuestions {
     /**
      * This question will return an answer with confidenceCategory=LOW
      */
-    public static final String LOW_CONFIDENCE = "how do I";
+    public static final String LOW_CONFIDENCE = "How does the classifier improve";
 
     /**
      * This question will return an empty answer list
      */
-    public static final String NO_ANSWERS = "hey";
+    public static final String NO_ANSWERS = "no";
 }

--- a/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/rest/impl/ConversationApiImpl.java
+++ b/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/rest/impl/ConversationApiImpl.java
@@ -58,9 +58,6 @@ import com.ibm.watson.app.qaclassifier.util.rest.MessageKey;
 public class ConversationApiImpl extends AbstractRestApiImpl implements ConversationApiInterface, ConfigurationConstants {
     private static final Logger logger = LogManager.getLogger();
 
-    public static final int HIGH_CONF_ANSWER_COUNT = 6;
-    public static final int LOW_CONF_ANSWER_COUNT = HIGH_CONF_ANSWER_COUNT - 1;
-
     private final NLClassifierService service;
     private final AnswerResolver resolver;
     private final UserTracking tracking;
@@ -193,15 +190,6 @@ public class ConversationApiImpl extends AbstractRestApiImpl implements Conversa
         
         if(answers.size() > 0) {
             answers = categorizer.categorize(answers);
-        }
-        
-        if (answers.size() > 0) {
-            // Ensure that the classifier returned more than one class that we were able to resolve
-            if (answers.get(0).getConfidenceCategory().equals(ConfidenceCategoryEnum.HIGH)) {
-                answers.subList(Math.min(answers.size(), HIGH_CONF_ANSWER_COUNT), answers.size()).clear();
-            } else {
-                answers.subList(Math.min(answers.size(), LOW_CONF_ANSWER_COUNT), answers.size()).clear();
-            }
         }
 
         String previousMessageId = null;

--- a/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/services/rest/impl/CumulativeConfidenceCategorizer.java
+++ b/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/services/rest/impl/CumulativeConfidenceCategorizer.java
@@ -70,30 +70,38 @@ public class CumulativeConfidenceCategorizer extends ConfigurationBasedConfidenc
     
     @Override
     public List<Answer> categorize(List<Answer> answersIn) {
-        final List<Answer> answers = new ArrayList<>(answersIn);
-        if(answers.size() == 0) {
+        
+        if(answersIn.size() == 0) {
             return Collections.emptyList();
         }
         
+        int answerCount = Math.min(answersIn.size(), count);
+        
         // If first answer is greater than the threshold, HIGH
-        Answer firstAnswer = answers.get(0);
+        Answer firstAnswer = answersIn.get(0);
         if(firstAnswer.getConfidence() >= threshold) {
-            for(Answer answer : answers) {
-                answer.setConfidenceCategory(ConfidenceCategoryEnum.HIGH);
-            }
+        	List<Answer> answers = new ArrayList<>();
+        	// Return top answer plus $count refinement suggestions
+        	for (int i = 0; i < Math.min(answerCount + 1, answersIn.size()); i++) {
+        		Answer answer = answersIn.get(i);
+        		answer.setConfidenceCategory(ConfidenceCategoryEnum.HIGH);
+        		answers.add(answer);
+        	}
             return answers;
         }
         
         // If sum of top N answers confidence > threshold, LOW
         double sum = 0.0d;
-        int n = Math.min(answers.size(), count);
-        for(int i = 0; i < n; i++) {
-            sum += answers.get(i).getConfidence();
+        for(int i = 0; i < answerCount; i++) {
+            sum += answersIn.get(i).getConfidence();
         }
         if(sum >= threshold) {
-            for(Answer answer : answers) {
-                answer.setConfidenceCategory(ConfidenceCategoryEnum.LOW);
-            }
+        	final List<Answer> answers = new ArrayList<>();
+        	for (int i = 0; i < answerCount; i++) {
+        		Answer answer = answersIn.get(i);
+        		answer.setConfidenceCategory(ConfidenceCategoryEnum.LOW);
+        		answers.add(answer);
+        	}
             return answers;
         }
         

--- a/questions-with-classifier-ega-war/src/main/resources/config/config.properties
+++ b/questions-with-classifier-ega-war/src/main/resources/config/config.properties
@@ -15,11 +15,11 @@
 # This is the threshold for calculating the confidence category (HIGH or LOW). Implementations consider a value 
 # above this threshold as HIGH, and below it LOW. Depending on the chosen categorizer, this value may be applied differently 
 # (i.e. some categorizers look at more than a single answer's confidence to determine if the threshold is reached)
-confidence.threshold=0.90
+confidence.threshold=0.80
 
 # Used by the CumulativeConfidenceCategorizer. This determines how many of the top answers 
 # the categorizer should use when summing their confidence values to determine if the threshold is reached.
-confidence.count=3
+confidence.count=5
 
 # These configuration properties are only used in an unmanaged environment (e.g. local)
 # They are not used when running within a managed container (e.g. Liberty)

--- a/questions-with-classifier-ega-war/src/test/java/com/ibm/watson/app/qaclassifier/rest/impl/ConversationApiImplTest.java
+++ b/questions-with-classifier-ega-war/src/test/java/com/ibm/watson/app/qaclassifier/rest/impl/ConversationApiImplTest.java
@@ -285,8 +285,7 @@ public class ConversationApiImplTest extends BaseRestApiTest {
             AND.verify_classify_was_invoked_on(availableClassifier);
             AND.verify_the_response_is_not_null();
             AND.verify_the_response_is_a(MessageResponse.class);
-            AND.verify_the_response_number_of_answers_is(ConversationApiImpl.HIGH_CONF_ANSWER_COUNT);
-                AND.verify_the_answer_list_contains_answer("example answer 1", 0.88, ConfidenceCategoryEnum.HIGH);
+            AND.verify_the_answer_list_contains_answer("example answer 1", 0.88, ConfidenceCategoryEnum.HIGH);
             AND.verify_tracked_a_query("What is the NL Classifier?");
     }
     
@@ -309,8 +308,7 @@ public class ConversationApiImplTest extends BaseRestApiTest {
             AND.verify_classify_was_invoked_on(availableClassifier);
             AND.verify_the_response_is_not_null();
             AND.verify_the_response_is_a(MessageResponse.class);
-            AND.verify_the_response_number_of_answers_is(ConversationApiImpl.LOW_CONF_ANSWER_COUNT);
-                AND.verify_the_answer_list_contains_answer("example answer 1", 0.34, ConfidenceCategoryEnum.LOW);
+            AND.verify_the_answer_list_contains_answer("example answer 1", 0.34, ConfidenceCategoryEnum.LOW);
             AND.verify_tracked_a_query("What is the NL Classifier?");
     }
     

--- a/questions-with-classifier-ega-war/src/test/java/com/ibm/watson/app/qaclassifier/services/rest/impl/CumulativeConfidenceCategorizerTest.java
+++ b/questions-with-classifier-ega-war/src/test/java/com/ibm/watson/app/qaclassifier/services/rest/impl/CumulativeConfidenceCategorizerTest.java
@@ -17,6 +17,7 @@ package com.ibm.watson.app.qaclassifier.services.rest.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -24,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -103,6 +105,7 @@ public class CumulativeConfidenceCategorizerTest implements ConfigurationConstan
             AND.categorize_is_invoked();
         THEN.the_category_is_not_null();
             AND.the_category_is_high();
+            AND.the_answer_list_has_size(4);
     }
     
     @Test
@@ -114,6 +117,7 @@ public class CumulativeConfidenceCategorizerTest implements ConfigurationConstan
             AND.categorize_is_invoked();
         THEN.the_category_is_not_null();
             AND.the_category_is_low();
+            AND.the_answer_list_has_size(3);
     }
     
     @Test
@@ -136,6 +140,10 @@ public class CumulativeConfidenceCategorizerTest implements ConfigurationConstan
     
     private void the_answer_list_is_empty() {
         assertTrue(answers.isEmpty());
+    }
+    
+    private void the_answer_list_has_size(int size) {
+        assertThat("", answers, Matchers.<Answer>hasSize(size));
     }
     
     private void the_category_is_low() {


### PR DESCRIPTION
Currently ConversationApiImpl is configured to return a certain number
of answers, depending on the confidence category.  And
CumulativeConfidenceCategorizer is configured to look at a certain
number of answers when determining the confidence category.  These two
numbers should be the same.

In order to avoid having to keep two configured numbers in sync, handle
trimming the answer list in the categorizer, rather than in the api
implementation.