### PR TITLE
Don't wait for feedback API calls to return

### DIFF
--- a/questions-with-classifier-ega-war/src/main/webapp/dev/js/ConversationStore.js
+++ b/questions-with-classifier-ega-war/src/main/webapp/dev/js/ConversationStore.js
@@ -120,8 +120,7 @@ function ConversationStore() {
 	 * None of the above was clicked, so let's log that feedback
 	 */
     self.on(action.NONE_OF_THE_ABOVE_CLICKED, function(messageData){
-        // The call to the server is for feedback only, so we don't need 
-        // to wait for it to trigger the broadcast action
+        // Don't wait for feedback API calls to return
         self.trigger(action.NONE_OF_THE_ABOVE_CLICKED_BROADCAST);
         
         var postData = {
@@ -149,6 +148,9 @@ function ConversationStore() {
      * The user clicked on something to provide negative feedback
      */
     self.on(action.NEGATIVE_FEEDBACK_GIVEN, function() {
+    	// Don't wait for feedback API calls to return
+    	self.trigger(action.NEGATIVE_FEEDBACK_RECEIVED_BROADCAST);
+    	
         var postData = {
             "conversationId": self.conversation.conversationId,
             "messageId": self.conversation.messageId,
@@ -164,8 +166,6 @@ function ConversationStore() {
             if (response.status < 200 || response.status >= 300) {
                 throw new Error(response.statusText);
             }
-            
-            self.trigger(action.NEGATIVE_FEEDBACK_RECEIVED_BROADCAST);
         })
         .catch(function(error) {
             self.trigger(action.SERVER_ERROR_BROADCAST, error);
@@ -176,6 +176,9 @@ function ConversationStore() {
      * The user clicked on something to provide positive feedback
      */
     self.on(action.POSITIVE_FEEDBACK_GIVEN, function() {
+    	// Don't wait for feedback API calls to return
+    	self.trigger(action.POSITIVE_FEEDBACK_RECEIVED_BROADCAST);
+    	
         var postData = {
             "conversationId": self.conversation.conversationId,
             "messageId": self.conversation.messageId,
@@ -190,9 +193,7 @@ function ConversationStore() {
         .then(function(response) {
             if (response.status < 200 || response.status >= 300) {
                 throw new Error(response.statusText);
-            }
-            
-            self.trigger(action.POSITIVE_FEEDBACK_RECEIVED_BROADCAST);
+            }   
         })
         .catch(function(error) {
             self.trigger(action.SERVER_ERROR_BROADCAST, error);


### PR DESCRIPTION
Since the responses from the feedback API calls don't return any useful
information, there's no need to wait for them to return.  Immediately
fire the broadcast event, and then make the feedback API request.

We still want to display the error screen if a feedback API request
fails, mostly so we can catch issues during testing.