### PR TITLE
Submit feedback request when user clicks none of the above

### DIFF
--- a/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/selenium/CommonFunctions.java
+++ b/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/selenium/CommonFunctions.java
@@ -104,6 +104,14 @@ public class CommonFunctions {
         }
         return ((HasCapabilities) driver).getCapabilities().getBrowserName();
     }
+    
+    public static WebElement findNoneOfTheAboveButton(WebDriver driver) {
+    	return driver.findElement(By.className("none"));
+    }
+    
+    public static WebElement findVisitTheForumButton(WebDriver driver) {
+    	return driver.findElement(By.className("visitForum"));
+    }
 
     private static void waitForAnswer(WebDriver driver) {
         // We know that an answer has been returned when the answer tag has a child element.

--- a/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/selenium/FeedbackScreensIT.java
+++ b/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/selenium/FeedbackScreensIT.java
@@ -17,8 +17,11 @@ package com.ibm.watson.app.qaclassifier.selenium;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -92,6 +95,31 @@ public class FeedbackScreensIT {
             assertThat("After 'I still need help' button was pressed, text input could not be made for another question",
             		driver.findElements(By.id("askButton")), hasSize(1));
         }
+    }
+    
+    @Test
+    public void userCanVisitForum() {
+    	CommonFunctions.askQuestionViaTextInput(driver, SampleQuestions.LOW_CONFIDENCE);
+    	
+    	WebElement noneOfTheAboveButton = CommonFunctions.findNoneOfTheAboveButton(driver);
+    	assertTrue("After asking low-confidence question, expect to find none of the above button",
+    			noneOfTheAboveButton.isDisplayed());
+    	noneOfTheAboveButton.click();
+    	
+    	WebElement forumButton = CommonFunctions.findVisitTheForumButton(driver);
+    	assertTrue("After clicking none of the above button, expect to find visit the forum button",
+    			forumButton.isDisplayed());
+    	forumButton.click();
+    	
+        ArrayList<String> tabs = new ArrayList<String> (driver.getWindowHandles());
+        driver.switchTo().window(tabs.get(1)); //Access new tab
+        assertThat("After clicking on the forum button, page is redirected",
+        		driver.getTitle(), is("natural-language-classifier - dWAnswers"));
+        
+        driver.close();
+        driver.switchTo().window(tabs.get(0));
+        
+        // Can't verify that the feedback was logged, but the log scans will catch any errors.
     }
 
 

--- a/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/selenium/HighLowConfidenceAnswersIT.java
+++ b/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/selenium/HighLowConfidenceAnswersIT.java
@@ -16,8 +16,11 @@
 package com.ibm.watson.app.qaclassifier.selenium;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,6 +74,16 @@ public class HighLowConfidenceAnswersIT {
 
         assertTrue("After asking question via text input, find the forum button in Still Need Help section",
                 visitForumButtonFound());
+        
+        CommonFunctions.findVisitTheForumButton(driver).click();
+        
+        ArrayList<String> tabs = new ArrayList<String> (driver.getWindowHandles());
+        driver.switchTo().window(tabs.get(1));
+        assertThat("After clicking on the forum button, page is redirected",
+        		driver.getTitle(), is("natural-language-classifier - dWAnswers"));
+        
+        driver.close();
+        driver.switchTo().window(tabs.get(0));
     }
 
     private String getDisplayedQuestionText() {
@@ -82,10 +95,10 @@ public class HighLowConfidenceAnswersIT {
     }
     
     private Boolean findNoneOfTheAboveButton() {
-    	return driver.findElement(By.className("none")).isDisplayed();
+    	return CommonFunctions.findNoneOfTheAboveButton(driver).isDisplayed();
     }
     
     private Boolean visitForumButtonFound() {
-    	return driver.findElement(By.className("visitForum")).isDisplayed();
+    	return CommonFunctions.findVisitTheForumButton(driver).isDisplayed();
     }
 }

--- a/questions-with-classifier-ega-war/src/main/webapp/dev/js/ConversationStore.js
+++ b/questions-with-classifier-ega-war/src/main/webapp/dev/js/ConversationStore.js
@@ -119,7 +119,7 @@ function ConversationStore() {
 	/**
 	 * None of the above was clicked, so let's log that feedback
 	 */
-    self.on(action.NONE_OF_THE_ABOVE_CLICKED, function(messageData){
+    self.on(action.NONE_OF_THE_ABOVE_CLICKED, function(){
         // Don't wait for feedback API calls to return
         self.trigger(action.NONE_OF_THE_ABOVE_CLICKED_BROADCAST);
         

--- a/questions-with-classifier-ega-war/src/main/webapp/dev/tag/alternative-questions.tag
+++ b/questions-with-classifier-ega-war/src/main/webapp/dev/tag/alternative-questions.tag
@@ -47,6 +47,8 @@
     }
     
     noneOfTheAbove(e) {
+    	Dispatcher.trigger(action.NONE_OF_THE_ABOVE_CLICKED);
+    	
     	self.showStillNeedHelp = true;
         self.noneOfAboveLabel.innerHTML = "<img src=\"images/Badge_88.svg\" class=\"yayIcon\" />" + polyglot.t("thanksForFeedbackMessage");
         self.noneOfAboveLabel.classList.add("selected");


### PR DESCRIPTION
Add tests that click the forum button for both the low-confidence and
no-answer cases.  Since the feedback API requests can fail silently,
there's no easy way to verify them at the moment.  But the exceptions in
the logs will be caught by the log scan tests.