### PR TITLE
Check question length in conversation API

### DIFF
--- a/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/rest/impl/ConversationApiImpl.java
+++ b/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/rest/impl/ConversationApiImpl.java
@@ -56,6 +56,8 @@ import com.ibm.watson.app.qaclassifier.services.rest.UserTracking.InputMode;
 import com.ibm.watson.app.qaclassifier.util.rest.MessageKey;
 
 public class ConversationApiImpl extends AbstractRestApiImpl implements ConversationApiInterface, ConfigurationConstants {
+    public static final int MAX_QUESTION_LENGTH = 1024;
+
     private static final Logger logger = LogManager.getLogger();
 
     private final NLClassifierService service;
@@ -121,6 +123,10 @@ public class ConversationApiImpl extends AbstractRestApiImpl implements Conversa
             if (message.getReferrer().getSource() == null) {
                 return getBadRequestResponse("referrer source required when referrer is set");
             }
+        }
+        
+        if (message.getMessage().length() > MAX_QUESTION_LENGTH) {
+        	return getBadRequestResponse(MessageKey.AQWQAC14004E_question_too_long_1.getMessage(message.getMessage()).getFormattedMessage());
         }
         
         if (service == null) {

--- a/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/util/rest/MessageKey.java
+++ b/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/util/rest/MessageKey.java
@@ -73,6 +73,7 @@ public enum MessageKey {
     AQWQAC14002E_no_classifier_instances(0),
     AQWQAC14003E_no_available_classifiers(0),
     AQWQAC24012E_conf_service_null(0),
+    AQWQAC14004E_question_too_long_1(1),
     
     ;
 

--- a/questions-with-classifier-ega-war/src/main/resources/messages/messages.properties
+++ b/questions-with-classifier-ega-war/src/main/resources/messages/messages.properties
@@ -47,6 +47,7 @@ AQWQAC14000E_could_not_find_classifier_service_in_conf_classification_unavail_1 
 AQWQAC14001E_error_selection_correct_classifier = There was an error selecting the correct classifier service
 AQWQAC14002E_no_classifier_instances = There are no classifier instances
 AQWQAC14003E_no_available_classifiers = There are no available classifiers
+AQWQAC14004E_question_too_long_1 = Question is longer than the maximum of 1024 characters: {0}
 
 AQWQAC22000W_no_top_questions_found_in_file_1 = No top questions found in {0}
 AQWQAC24150E_could_not_find_key_in_db_1 = Could not find key {0} in database

--- a/questions-with-classifier-ega-war/src/test/java/com/ibm/watson/app/qaclassifier/rest/impl/ConversationApiImplTest.java
+++ b/questions-with-classifier-ega-war/src/test/java/com/ibm/watson/app/qaclassifier/rest/impl/ConversationApiImplTest.java
@@ -123,7 +123,7 @@ public class ConversationApiImplTest extends BaseRestApiTest {
             AND.the_conversation_api_is_created();
         WHEN.ask_question_is_invoked_with_question("What is the NL Classifier?");
         THEN.a_server_error_is_returned();
-            AND.the_response_entity_is_an_error_respone();
+            AND.the_response_entity_is_an_error_response();
             AND.the_error_message_is(MessageKey.AQWQAC14001E_error_selection_correct_classifier.getMessage().getFormattedMessage());
     }
     
@@ -133,7 +133,7 @@ public class ConversationApiImplTest extends BaseRestApiTest {
             AND.the_conversation_api_is_created();
         WHEN.ask_question_is_invoked_with_question("What is the NL Classifier?");
         THEN.a_server_error_is_returned();
-            AND.the_response_entity_is_an_error_respone();
+            AND.the_response_entity_is_an_error_response();
             AND.the_error_message_is(MessageKey.AQWQAC14002E_no_classifier_instances.getMessage().getFormattedMessage());
     }
     
@@ -144,7 +144,7 @@ public class ConversationApiImplTest extends BaseRestApiTest {
             AND.the_conversation_api_is_created();
         WHEN.ask_question_is_invoked_with_question("What is the NL Classifier?");
         THEN.a_server_error_is_returned();
-            AND.the_response_entity_is_an_error_respone();
+            AND.the_response_entity_is_an_error_response();
             AND.the_error_message_is(MessageKey.AQWQAC14003E_no_available_classifiers.getMessage().getFormattedMessage());
     }
     
@@ -224,7 +224,7 @@ public class ConversationApiImplTest extends BaseRestApiTest {
             AND.the_conversation_api_is_created();
         WHEN.ask_question_is_invoked_with_question("What is the NL Classifier?");
         THEN.a_server_error_is_returned();
-            AND.the_response_entity_is_an_error_respone();
+            AND.the_response_entity_is_an_error_response();
             AND.the_error_message_is(MessageKey.AQWQAC14001E_error_selection_correct_classifier.getMessage().getFormattedMessage());
     }
     
@@ -236,7 +236,7 @@ public class ConversationApiImplTest extends BaseRestApiTest {
             AND.the_conversation_api_is_created();
         WHEN.ask_question_is_invoked_with_question("What is the NL Classifier?");
         THEN.a_server_error_is_returned();
-            AND.the_response_entity_is_an_error_respone();
+            AND.the_response_entity_is_an_error_response();
             AND.the_error_message_is(MessageKey.AQWQAC14001E_error_selection_correct_classifier.getMessage().getFormattedMessage());
     }
     
@@ -404,6 +404,21 @@ public class ConversationApiImplTest extends BaseRestApiTest {
             AND.verify_put_was_invoked_on_response_cache(CONVERSATION_ID);
     }
     
+    @Test
+    public void test_ask_question_too_long() throws Exception {
+    	StringBuilder longQuestion = new StringBuilder();
+    	for (int i=0; i <= ConversationApiImpl.MAX_QUESTION_LENGTH / "hello ".length(); i++) {
+    		longQuestion.append("hello ");
+    	}
+    	GIVEN.the_classifier_service_is_mocked();
+        	WITH.an_available_classifier_instance();
+        	AND.the_conversation_api_is_created();
+        WHEN.ask_question_is_invoked_with_question(longQuestion.toString());
+        THEN.a_bad_request_error_is_returned();
+	        AND.the_response_entity_is_an_error_response();
+	        AND.the_error_message_is(MessageKey.AQWQAC14004E_question_too_long_1.getMessage(longQuestion.toString()).getFormattedMessage());
+    }
+    
     private void verify_put_was_invoked_on_response_cache(String conversationId) {
         verify(responseCache, times(1)).put(eq(CONVERSATION_ID), Matchers.anyListOf(Answer.class));
     }
@@ -464,12 +479,16 @@ public class ConversationApiImplTest extends BaseRestApiTest {
         assertEquals(errorMsg, ((ErrorResponse)response.getEntity()).getMessage());
     }
     
-    private void the_response_entity_is_an_error_respone() {
+    private void the_response_entity_is_an_error_response() {
         assertTrue(response.getEntity() instanceof ErrorResponse);
     }
 
     private void a_server_error_is_returned() {
         assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+    }
+    
+    private void a_bad_request_error_is_returned() {
+    	assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
     
     private void ask_question_is_invoked_with_question_and_referrer(String question, MessageRequestReferrer referrer) throws NotFoundException {


### PR DESCRIPTION
Questions over 1024 characters won't be answered by the classifier, and
they're too big to fit in the tracking DB, so return 400 bad request
when a user submits a question longer than 1024 characters.

We already catch this in the UI, so this covers the additional case that
someone might access the API directly

Ready for review.