### PR TITLE
Fix Selenium tab switching

### DIFF
--- a/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/selenium/CommonFunctions.java
+++ b/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/selenium/CommonFunctions.java
@@ -16,6 +16,9 @@
 
 package com.ibm.watson.app.qaclassifier.selenium;
 
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
 import org.openqa.selenium.By;
 import org.openqa.selenium.HasCapabilities;
 import org.openqa.selenium.WebDriver;
@@ -113,14 +116,29 @@ public class CommonFunctions {
     	return driver.findElement(By.className("visitForum"));
     }
     
-	public static void waitForTabToOpen(WebDriver driver) {
-		new WebDriverWait(driver, 2).until(new Predicate<WebDriver>() {
-			@Override
-			public boolean apply(WebDriver input) {
-				return input.getWindowHandles().size() == 2;
-			}
-		});
-	}
+    public static void switchTabs(WebDriver driver) {
+        String currentHandle = driver.getWindowHandle();
+
+        new WebDriverWait(driver, 2).until(new Predicate<WebDriver>() {
+            @Override
+            public boolean apply(WebDriver input) {
+                return input.getWindowHandles().size() > 1;
+            }
+
+            @Override
+            public String toString() {
+                return "tab to open";
+            }
+        });
+
+        assertThat("Expected to find two browser tabs", driver.getWindowHandles(), hasSize(2));
+
+        for (String handle : driver.getWindowHandles()) {
+            if (!handle.equals(currentHandle)) {
+                driver.switchTo().window(handle);
+            }
+        }
+    }
 
     private static void waitForAnswer(WebDriver driver) {
         // We know that an answer has been returned when the answer tag has a child element.

--- a/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/selenium/FeedbackScreensIT.java
+++ b/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/selenium/FeedbackScreensIT.java
@@ -21,8 +21,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
@@ -111,15 +109,12 @@ public class FeedbackScreensIT {
     			forumButton.isDisplayed());
     	forumButton.click();
     	
-    	CommonFunctions.waitForTabToOpen(driver);
-        ArrayList<String> tabs = new ArrayList<String> (driver.getWindowHandles());
-        driver.switchTo().window(tabs.get(1)); //Access new tab
+    	CommonFunctions.switchTabs(driver);
         assertThat("After clicking on the forum button, page is redirected",
         		driver.getTitle(), is("natural-language-classifier - dWAnswers"));
         
         driver.close();
-        driver.switchTo().window(tabs.get(0));
-        
+
         // Can't verify that the feedback was logged, but the log scans will catch any errors.
     }
 

--- a/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/selenium/HighLowConfidenceAnswersIT.java
+++ b/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/selenium/HighLowConfidenceAnswersIT.java
@@ -20,8 +20,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
@@ -76,15 +74,10 @@ public class HighLowConfidenceAnswersIT {
                 visitForumButtonFound());
         
         CommonFunctions.findVisitTheForumButton(driver).click();
-
-        CommonFunctions.waitForTabToOpen(driver);
-        ArrayList<String> tabs = new ArrayList<String> (driver.getWindowHandles());
-        driver.switchTo().window(tabs.get(1));
+        CommonFunctions.switchTabs(driver);
         assertThat("After clicking on the forum button, page is redirected",
         		driver.getTitle(), is("natural-language-classifier - dWAnswers"));
-        
         driver.close();
-        driver.switchTo().window(tabs.get(0));
     }
 
     private String getDisplayedQuestionText() {

--- a/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/selenium/MenuMobileIT.java
+++ b/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/selenium/MenuMobileIT.java
@@ -20,7 +20,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
@@ -99,15 +98,10 @@ public class MenuMobileIT {
         documentationOption.click();
         
         //New tab with documentation is opened
-        CommonFunctions.waitForTabToOpen(driver);
-        ArrayList<String> tabs = new ArrayList<String> (driver.getWindowHandles()); //Get all existing tabs
-        driver.switchTo().window(tabs.get(1)); //Access new tab
-        
+        CommonFunctions.switchTabs(driver);
         assertThat("After clicking on the menu option, page is redirected",
         		driver.getTitle(), is("Natural Language Classifier service documentation | Watson Developer Cloud"));
-        
         driver.close();
-        driver.switchTo().window(tabs.get(0));
     }
     
 }

--- a/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/selenium/drivers/SkipWelcomeScreenRule.java
+++ b/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/selenium/drivers/SkipWelcomeScreenRule.java
@@ -70,7 +70,17 @@ public class SkipWelcomeScreenRule extends ExternalResource {
             CommonFunctions.waitForApp(driver);
         }
     }
-    
+
+    @Override
+    protected void after() {
+        // Clean up any extra open tabs.
+        WebDriver driver = driverRef.get();
+        while (driver.getWindowHandles().size() > 1) {
+            driver.close();
+        }
+        driver.switchTo().window(driver.getWindowHandles().iterator().next());
+    }
+
     private void skipWelcomeScreen() throws InterruptedException {
         WebDriver driver = driverRef.get();
         // In some cases on Internet Explorer it can take more than five seconds for this to appear.


### PR DESCRIPTION
Consolidate the logic for dealing with tabs into one place and do it
correctly- don't assume driver.getWindowHandles() will return tabs in a
specific order.

Also perform tab cleanup after a test completes to ensure we never have
old tabs open from a previous test.

Ready for review.