### PR TITLE
Allows output filenames without path for aout/qout

### DIFF
--- a/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/tools/GenerateTrainingAndPopulationData.java
+++ b/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/tools/GenerateTrainingAndPopulationData.java
@@ -359,13 +359,13 @@ public class GenerateTrainingAndPopulationData {
         
         // make sure we can create the question output file
         questionOutput = new File(questionOutputFile);
-        if( !questionOutput.getParentFile().exists() && !questionOutput.getParentFile().mkdirs() ) {
+        if( (null != questionOutput.getParentFile()) && !questionOutput.getParentFile().exists() && !questionOutput.getParentFile().mkdirs() ) {
             throw new IllegalArgumentException(MessageKey.AQWQAC14202E_unable_create_parent_dir_for_file_1.getMessage(questionOutput.getAbsolutePath()).getFormattedMessage());
         }       
 
         // make sure we can create the question output file
         answerOutput = new File(answerOutputFile);
-        if( !answerOutput.getParentFile().exists() && !answerOutput.getParentFile().mkdirs() ) {
+        if( (null != answerOutput.getParentFile()) && !answerOutput.getParentFile().exists() && !answerOutput.getParentFile().mkdirs() ) {
             throw new IllegalArgumentException(MessageKey.AQWQAC14202E_unable_create_parent_dir_for_file_1.getMessage(answerOutput.getAbsolutePath()).getFormattedMessage());
         }       
     }


### PR DESCRIPTION
This tool cause NullPointerException when I specified file names without path info for qout/aout. I added one more check if path info has been specified, which allows us to write output at the current folder.