### PR TITLE
Add CORS filter support and add allow cross origin to response headers

### DIFF
--- a/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/rest/api/StatusIT.java
+++ b/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/rest/api/StatusIT.java
@@ -33,6 +33,7 @@ public class StatusIT {
         get("/api/v1/status")
                 .then().statusCode(200)
                 .and().contentType(ContentType.JSON)
+                .and().header("Access-Control-Allow-Origin", "*")
                 .and().body("status", is("good"));
     }
 }

--- a/questions-with-classifier-ega-war/src/main/webapp/WEB-INF/web.xml
+++ b/questions-with-classifier-ega-war/src/main/webapp/WEB-INF/web.xml
@@ -30,6 +30,15 @@
 		<res-sharing-scope>Shareable</res-sharing-scope>
 	</resource-ref>
   	
+  	<filter>
+    	<filter-name>CORSFilter</filter-name>
+		<filter-class>com.ibm.watson.app.common.util.rest.CORSFilter</filter-class>
+	</filter>
+	<filter-mapping>
+		<filter-name>CORSFilter</filter-name>
+		<url-pattern>/*</url-pattern>
+	</filter-mapping>
+  	
 	<servlet>
 		<description>Classifier API</description>
 		<servlet-name>Classifier JAX-RS Servlet</servlet-name>


### PR DESCRIPTION
Depends on Framework-ega adopting the CORS servlet filter.  This enables cross origin API requests to be fulfilled. 