### PR TITLE
Added metadata field to ManagedAnswer

### DIFF
--- a/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/AddQuestionsToMockClassifier.java
+++ b/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/AddQuestionsToMockClassifier.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.cli.CommandLine;
@@ -152,12 +153,14 @@ public class AddQuestionsToMockClassifier {
                 .contentType(ContentType.JSON)
                 .when().get(ANSWER_STORE_ENDPOINT + "/" + answerClass)
                 .thenReturn().statusCode();
+        
+        Map<String, String> metadata = com.google.common.collect.ImmutableMap.of("a", "b");
 
         if (statusCode == 404) {
             given().baseUri(url)
                     .auth().basic(user, password)
                     .contentType(ContentType.JSON)
-                    .body(Arrays.asList(new ManagedAnswer(answerClass, TypeEnum.TEXT, answerText, canonicalQuestion, "{}")))
+                    .body(Arrays.asList(new ManagedAnswer(answerClass, TypeEnum.TEXT, answerText, canonicalQuestion, metadata)))
                     .log().ifValidationFails()
                     .when().post(ANSWER_STORE_ENDPOINT)
                     .then().statusCode(200)

--- a/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/AddQuestionsToMockClassifier.java
+++ b/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/AddQuestionsToMockClassifier.java
@@ -157,7 +157,7 @@ public class AddQuestionsToMockClassifier {
             given().baseUri(url)
                     .auth().basic(user, password)
                     .contentType(ContentType.JSON)
-                    .body(Arrays.asList(new ManagedAnswer(answerClass, TypeEnum.TEXT, answerText, canonicalQuestion)))
+                    .body(Arrays.asList(new ManagedAnswer(answerClass, TypeEnum.TEXT, answerText, canonicalQuestion, "{}")))
                     .log().ifValidationFails()
                     .when().post(ANSWER_STORE_ENDPOINT)
                     .then().statusCode(200)

--- a/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/rest/api/ManageApiIT.java
+++ b/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/rest/api/ManageApiIT.java
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
+import java.util.HashMap;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
@@ -63,7 +64,7 @@ public class ManageApiIT {
         answer.setType(TypeEnum.TEXT);
         answer.setText("The text of the unknown answer");
         answer.setCanonicalQuestion("The canonical question for the unknown answer");
-        answer.setMetadata(ImmutableMap.of("a", "b"));
+        answer.setMetadata(new HashMap<String, String>());
         ManagedAnswer[] answers = {answer};
         String json = new Gson().toJson(answers);
 
@@ -80,7 +81,7 @@ public class ManageApiIT {
                 .and().body("type", is("TEXT"))
                 .and().body("text", is("The text of the unknown answer"))
                 .and().body("canonicalQuestion", is("The canonical question for the unknown answer"))
-                .and().body("metadata", hasEntry("a", "b"));
+                .and().body("metadata", is(new HashMap<String, String>()));
 
         delete("/api/v1/manage/answer/someunknownclass")
                 .then().statusCode(200);

--- a/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/rest/api/ManageApiIT.java
+++ b/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/rest/api/ManageApiIT.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.not;
@@ -37,6 +38,7 @@ import org.apache.commons.lang.StringUtils;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.ibm.watson.app.qaclassifier.rest.model.ManagedAnswer;
 import com.ibm.watson.app.qaclassifier.rest.model.ManagedAnswer.TypeEnum;
@@ -61,6 +63,7 @@ public class ManageApiIT {
         answer.setType(TypeEnum.TEXT);
         answer.setText("The text of the unknown answer");
         answer.setCanonicalQuestion("The canonical question for the unknown answer");
+        answer.setMetadata(ImmutableMap.of("a", "b"));
         ManagedAnswer[] answers = {answer};
         String json = new Gson().toJson(answers);
 
@@ -76,7 +79,8 @@ public class ManageApiIT {
                 .and().body("className", is("someunknownclass"))
                 .and().body("type", is("TEXT"))
                 .and().body("text", is("The text of the unknown answer"))
-                .and().body("canonicalQuestion", is("The canonical question for the unknown answer"));
+                .and().body("canonicalQuestion", is("The canonical question for the unknown answer"))
+                .and().body("metadata", hasEntry("a", "b"));
 
         delete("/api/v1/manage/answer/someunknownclass")
                 .then().statusCode(200);
@@ -98,6 +102,7 @@ public class ManageApiIT {
         answer.setType(TypeEnum.TEXT);
         answer.setText(answerText);
         answer.setCanonicalQuestion("The canonical question for the long answer");
+        answer.setMetadata(ImmutableMap.of("a", "b"));
         ManagedAnswer[] answers = {answer};
         String json = new Gson().toJson(answers);
 
@@ -113,7 +118,8 @@ public class ManageApiIT {
                 .and().body("className", is("longanswer"))
                 .and().body("type", is("TEXT"))
                 .and().body("text", is(answerText))
-                .and().body("canonicalQuestion", is("The canonical question for the long answer"));
+                .and().body("canonicalQuestion", is("The canonical question for the long answer"))
+                .and().body("metadata", hasEntry("a", "b"));
 
         delete("/api/v1/manage/answer/longanswer")
                 .then().statusCode(200);

--- a/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/rest/impl/ManageApiImpl.java
+++ b/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/rest/impl/ManageApiImpl.java
@@ -278,6 +278,7 @@ public class ManageApiImpl extends AbstractRestApiImpl implements ManageApiInter
         answer.setText(entity.getAnswerText());
         answer.setType(ManagedAnswer.TypeEnum.valueOf(entity.getAnswerType().name()));
         answer.setCanonicalQuestion(entity.getCanonicalQuestion());
+        answer.setMetadata(entity.getMetadata());
         return answer;
     }
 
@@ -287,6 +288,7 @@ public class ManageApiImpl extends AbstractRestApiImpl implements ManageApiInter
         entity.setAnswerText(answer.getText());
         entity.setAnswerType(Answer.TypeEnum.valueOf(answer.getType().name()));
         entity.setCanonicalQuestion(answer.getCanonicalQuestion());
+        entity.setMetadata(answer.getMetadata());
         return entity;
     }
 }

--- a/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/services/entities/AnswerEntity.java
+++ b/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/services/entities/AnswerEntity.java
@@ -93,13 +93,6 @@ public class AnswerEntity {
         this.canonicalQuestion = canonicalQuestion;
     }
     
-    public String getMetadata() {
-    	return metadata;
-    }
-    
-    public void setMetadata(String metadata) {
-    	this.metadata = metadata;
-    }
 
     public Map<String, String> getMetadata() {
     	return metadata;

--- a/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/services/entities/AnswerEntity.java
+++ b/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/services/entities/AnswerEntity.java
@@ -92,7 +92,6 @@ public class AnswerEntity {
     public void setCanonicalQuestion(String canonicalQuestion) {
         this.canonicalQuestion = canonicalQuestion;
     }
-    
 
     public Map<String, String> getMetadata() {
     	return metadata;

--- a/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/services/entities/AnswerEntity.java
+++ b/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/services/entities/AnswerEntity.java
@@ -49,7 +49,10 @@ public class AnswerEntity {
     
     @Column(name = "CANONICAL_QUESTION", unique = false, nullable = false)
     private String canonicalQuestion;
-
+    
+    @Column(name = "METADATA", unique = false)
+    private String metadata;
+    
     public String getAnswerClass() {
         return answerClass;
     }
@@ -81,9 +84,17 @@ public class AnswerEntity {
     public void setCanonicalQuestion(String canonicalQuestion) {
         this.canonicalQuestion = canonicalQuestion;
     }
+    
+    public String getMetadata() {
+    	return metadata;
+    }
+    
+    public void setMetadata(String metadata) {
+    	this.metadata = metadata;
+    }
 
     @Override
     public String toString() {
-        return "Answer [answerClass=" + answerClass + ", answerType=" + answerType + ", answerText=" + answerText + "]";
+        return "Answer [answerClass=" + answerClass + ", answerType=" + answerType + ", answerText=" + answerText + ", metadata=" + metadata + "]";
     }
 }

--- a/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/services/entities/AnswerEntity.java
+++ b/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/services/entities/AnswerEntity.java
@@ -15,12 +15,17 @@
 
 package com.ibm.watson.app.qaclassifier.services.entities;
 
+import java.util.Map;
+
+import javax.persistence.CollectionTable;
 import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.Lob;
+import javax.persistence.MapKeyColumn;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
@@ -49,9 +54,12 @@ public class AnswerEntity {
     
     @Column(name = "CANONICAL_QUESTION", unique = false, nullable = false)
     private String canonicalQuestion;
-    
-    @Column(name = "METADATA", unique = false)
-    private String metadata;
+
+    @ElementCollection
+    @MapKeyColumn(name = "METADATA_KEY")
+    @Column(name = "METADATA_VALUE")
+    @CollectionTable(name="METADATA")
+    private Map<String, String> metadata;
     
     public String getAnswerClass() {
         return answerClass;
@@ -93,6 +101,14 @@ public class AnswerEntity {
     	this.metadata = metadata;
     }
 
+    public Map<String, String> getMetadata() {
+    	return metadata;
+    }
+    
+    public void setMetadata(Map<String, String> metadata) {
+    	this.metadata = metadata;
+    }
+    
     @Override
     public String toString() {
         return "Answer [answerClass=" + answerClass + ", answerType=" + answerType + ", answerText=" + answerText + ", metadata=" + metadata + "]";

--- a/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/tools/PopulateAnswerStore.java
+++ b/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/tools/PopulateAnswerStore.java
@@ -142,7 +142,7 @@ public class PopulateAnswerStore {
         }
 
         // While we are at it, the mocked classifier service adds in "defaultClass", so lets set that too
-        ManagedAnswer defaultAnswer = new ManagedAnswer("defaultClass", TypeEnum.TEXT, "This answer is resolved from the default class", "Sample canonical question");
+        ManagedAnswer defaultAnswer = new ManagedAnswer("defaultClass", TypeEnum.TEXT, "This answer is resolved from the default class", "Sample canonical question", "{}");
         data.add(defaultAnswer);
         
         return data;

--- a/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/tools/PopulateAnswerStore.java
+++ b/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/tools/PopulateAnswerStore.java
@@ -20,6 +20,7 @@ import java.io.StringReader;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -141,8 +142,10 @@ public class PopulateAnswerStore {
             a.setText(formattedText);
         }
 
+        Map<String, String> metadata = com.google.common.collect.ImmutableMap.of("a", "b");
+        
         // While we are at it, the mocked classifier service adds in "defaultClass", so lets set that too
-        ManagedAnswer defaultAnswer = new ManagedAnswer("defaultClass", TypeEnum.TEXT, "This answer is resolved from the default class", "Sample canonical question", "{}");
+        ManagedAnswer defaultAnswer = new ManagedAnswer("defaultClass", TypeEnum.TEXT, "This answer is resolved from the default class", "Sample canonical question", metadata);
         data.add(defaultAnswer);
         
         return data;

--- a/questions-with-classifier-ega-war/src/main/webapp/api/doc/swagger.json
+++ b/questions-with-classifier-ega-war/src/main/webapp/api/doc/swagger.json
@@ -453,8 +453,11 @@
                     "description": "The canonical question for this answer"
                 },
                 "metadata": {
-                	"type": "string",
-                	"description": "A key-value mapping of metadata"
+                	"type": "object",
+                	"description": "String to string key-value mappings for metadata information",
+                	"additionalProperties": {
+                		"type": "string"
+                	}
                 }
             }
         },

--- a/questions-with-classifier-ega-war/src/main/webapp/api/doc/swagger.json
+++ b/questions-with-classifier-ega-war/src/main/webapp/api/doc/swagger.json
@@ -451,6 +451,10 @@
                 "canonicalQuestion": {
                     "type": "string",
                     "description": "The canonical question for this answer"
+                },
+                "metadata": {
+                	"type": "string",
+                	"description": "A key-value mapping of metadata"
                 }
             }
         },


### PR DESCRIPTION
Metadata in string form can be added to a ManagedAnswer now.
It doesn't enforce key-value mapping, so it's up to the user to make sure they're writing proper mappings.