### PR TITLE
Fixed bulk upload manage api

### DIFF
--- a/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/rest/api/ManageApiIT.java
+++ b/questions-with-classifier-ega-test/src/it/java/com/ibm/watson/app/qaclassifier/rest/api/ManageApiIT.java
@@ -125,6 +125,37 @@ public class ManageApiIT {
         delete("/api/v1/manage/answer/longanswer")
                 .then().statusCode(200);
     }
+    
+    @Test
+    public void test_create_and_recreate_answer() {
+        String answerClass = "createAndRecreateAnswer";
+
+        ensureAnswerDoesNotExist(answerClass);
+
+        ManagedAnswer answer = new ManagedAnswer(answerClass, TypeEnum.TEXT, "answer text", "answer question", new HashMap<String, String>());
+
+        given().contentType(ContentType.JSON)
+                .body(new ManagedAnswer[] {answer})
+                .post("/api/v1/manage/answer")
+                .then().statusCode(200);
+
+        given().pathParam("answerClass", answerClass)
+                .when().get("/api/v1/manage/answer/{answerClass}")
+                .then().statusCode(200)
+                .and().body("text", is("answer text"));
+
+        answer.setText("Modified answer text");
+
+        given().contentType(ContentType.JSON)
+                .body(new ManagedAnswer[] {answer})
+                .post("/api/v1/manage/answer")
+                .then().statusCode(200);
+
+        given().pathParam("answerClass", answerClass)
+                .when().get("/api/v1/manage/answer/{answerClass}")
+                .then().statusCode(200)
+                .and().body("text", is("Modified answer text"));
+    }
 
     @Test
     public void test_get_tracking_events_for_invalid_conversation() {

--- a/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/rest/impl/ManageApiImpl.java
+++ b/questions-with-classifier-ega-war/src/main/java/com/ibm/watson/app/qaclassifier/rest/impl/ManageApiImpl.java
@@ -231,7 +231,7 @@ public class ManageApiImpl extends AbstractRestApiImpl implements ManageApiInter
         try {
             trans.begin();
             for (AnswerEntity entity : entities) {
-                em.persist(entity);
+                em.merge(entity);
             }
             trans.commit();
         } finally {


### PR DESCRIPTION
Before we were using em.persist() for the bulk upload of answers.
Now we're using merge so existing copies can be updated or added if
they don't exist.

Caveats:  might be slower than before